### PR TITLE
increased the time before a PingPoll gets deleted

### DIFF
--- a/cogs/event_handler.py
+++ b/cogs/event_handler.py
@@ -45,7 +45,7 @@ class EventHandler(commands.Cog):
                         embed.add_field(name="Denied", value="Nobody")
                         await message.channel.send(
                             embed=embed,
-                            delete_after=900,
+                            delete_after=1200,
                             view=PingPoll(),
                         )
 

--- a/views/buttons/pingpoll.py
+++ b/views/buttons/pingpoll.py
@@ -4,7 +4,7 @@ from nextcord import Button, ButtonStyle, Embed, Interaction
 
 class PingPoll(nextcord.ui.View):
     def __init__(self):
-        super().__init__(timeout=900)
+        super().__init__(timeout=1200)
 
     async def update(self, interaction: Interaction, embed: Embed, button_index: int):
         user = interaction.user


### PR DESCRIPTION
I think this might be good idea, because i noticed that in my experience 15 minutes is just too short to notice the poll sometimes.

# Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested
- [ ] This PR adds a feature
  - [ ] This PR adds a slash command
  - [ ] This PR adds a view
  - [ ] This PR adds a cog
- [ ] This PR fixes an issue
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
